### PR TITLE
WIP - Move server version management logic into its own file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1970,6 +1970,12 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -2789,6 +2795,20 @@
         "lodash": "^4.17.14"
       }
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2803,6 +2823,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chokidar": {
       "version": "2.1.6",
@@ -4180,6 +4206,12 @@
         "ms": "2.0.0"
       }
     },
+    "debug-log": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+      "dev": true
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -4189,6 +4221,15 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -4265,6 +4306,28 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "deglob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-4.0.1.tgz",
+      "integrity": "sha512-/g+RDZ7yf2HvoW+E5Cy+K94YhgcFgr6C8LuHZD1O5HoNPkf3KY6RfXJ0DBGlB/NkLi5gml+G9zqRzk9S0mHZCg==",
+      "dev": true,
+      "requires": {
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^5.0.0",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
         }
       }
     },
@@ -4794,6 +4857,24 @@
         "confusing-browser-globals": "^1.0.8"
       }
     },
+    "eslint-config-semistandard": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-semistandard/-/eslint-config-semistandard-15.0.0.tgz",
+      "integrity": "sha512-volIMnosUvzyxGkYUA5QvwkahZZLeUx7wcS0+7QumPn+MMEBbV6P7BY1yukamMst0w3Et3QZlCjQEwQ8tQ6nug==",
+      "dev": true
+    },
+    "eslint-config-standard": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
+      "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
+      "dev": true
+    },
+    "eslint-config-standard-jsx": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
+      "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
+      "dev": true
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
@@ -4888,6 +4969,16 @@
             "find-up": "^2.1.0"
           }
         }
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.1.tgz",
+      "integrity": "sha512-5fa/gR2yR3NxQf+UXkeLeP8FBBl6tSgdrAz1+cF84v1FMM4twGwQoqTnn+QxFLcPOrF4pdKEJKDB/q9GoyJrCA==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^1.4.2",
+        "regexpp": "^2.0.1"
       }
     },
     "eslint-plugin-flowtype": {
@@ -5047,6 +5138,34 @@
         }
       }
     },
+    "eslint-plugin-node": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-9.1.0.tgz",
+      "integrity": "sha512-ZwQYGm6EoV2cfLpE1wxJWsfnKUIXfM/KM09/TlorkukgCAwmkgajEJnPCmyzoFPQQkmvo5DrW/nyKutNIw36Mw==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^1.4.0",
+        "eslint-utils": "^1.3.1",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "dev": true
+    },
     "eslint-plugin-react": {
       "version": "7.14.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
@@ -5078,6 +5197,12 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
       "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA=="
     },
+    "eslint-plugin-standard": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
+      "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -5088,9 +5213,9 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
       "requires": {
         "eslint-visitor-keys": "^1.0.0"
       }
@@ -5597,6 +5722,12 @@
         "pkg-dir": "^3.0.0"
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -5872,10 +6003,22 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
       "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg=="
+    },
+    "get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "dev": true
     },
     "get-stream": {
       "version": "4.1.0",
@@ -9183,6 +9326,37 @@
         "lower-case": "^1.1.1"
       }
     },
+    "nock": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-11.3.1.tgz",
+      "integrity": "sha512-fsFRKNoH6R6hQuaasbAS5vmy4ujVaqKOb/9NCFP0TkhwbH1e5bPN8bn37FCIF9/0ZhayBrClUmSbN6Rm61+WSg==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.13",
+        "mkdirp": "^0.5.0",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "node-environment-flags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
@@ -9897,6 +10071,12 @@
         "pify": "^3.0.0"
       }
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "pause": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
@@ -9948,6 +10128,54 @@
       "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
       "requires": {
         "node-modules-regexp": "^1.0.0"
+      }
+    },
+    "pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "parse-json": "^4.0.0",
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
+        }
+      }
+    },
+    "pkg-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+      "dev": true,
+      "requires": {
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "pkg-dir": {
@@ -10953,6 +11181,12 @@
         "react-is": "^16.8.1"
       }
     },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
+    },
     "proxy-addr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -11815,6 +12049,12 @@
         "is-promise": "^2.1.0"
       }
     },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
+    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -11956,6 +12196,135 @@
       "integrity": "sha512-9AukTiDmHXGXWtWjembZ5NDmVvP2695EtpgbCsxCa68w3c88B+alqbmZ4O3hZ4VWGXeGWzEVdvqgAJD8DQPCDw==",
       "requires": {
         "node-forge": "0.7.5"
+      }
+    },
+    "semistandard": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/semistandard/-/semistandard-14.1.0.tgz",
+      "integrity": "sha512-yZFF1dVmetxrwnUZaxk0adKWLzut/zK8WaX2rF9LhynBafsAAaaWHKbFHCsJGb17TOno7JhtB22XOiEpMVdN/g==",
+      "dev": true,
+      "requires": {
+        "eslint": "~6.2.2",
+        "eslint-config-semistandard": "15.0.0",
+        "eslint-config-standard": "14.1.0",
+        "eslint-config-standard-jsx": "8.1.0",
+        "eslint-plugin-import": "~2.18.0",
+        "eslint-plugin-node": "~9.1.0",
+        "eslint-plugin-promise": "~4.2.1",
+        "eslint-plugin-react": "~7.14.2",
+        "eslint-plugin-standard": "~4.0.0",
+        "standard-engine": "^12.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
+          "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+          "dev": true
+        },
+        "acorn-jsx": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
+          "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eslint": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.2.2.tgz",
+          "integrity": "sha512-mf0elOkxHbdyGX1IJEUsNBzCDdyoUgljF3rRlgfyYh0pwGnreLc0jjD6ZuleOibjmnUWZLY2eXwSooeOgGJ2jw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "ajv": "^6.10.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^4.0.1",
+            "doctrine": "^3.0.0",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^1.4.2",
+            "eslint-visitor-keys": "^1.1.0",
+            "espree": "^6.1.1",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^5.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "glob-parent": "^5.0.0",
+            "globals": "^11.7.0",
+            "ignore": "^4.0.6",
+            "import-fresh": "^3.0.0",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^6.4.1",
+            "is-glob": "^4.0.0",
+            "js-yaml": "^3.13.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.14",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "progress": "^2.0.0",
+            "regexpp": "^2.0.1",
+            "semver": "^6.1.2",
+            "strip-ansi": "^5.2.0",
+            "strip-json-comments": "^3.0.1",
+            "table": "^5.2.3",
+            "text-table": "^0.2.0",
+            "v8-compile-cache": "^2.0.3"
+          }
+        },
+        "eslint-scope": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "espree": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
+          "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.0.0",
+            "acorn-jsx": "^5.0.2",
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "import-fresh": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+          "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
       }
     },
     "semver": {
@@ -12552,6 +12921,18 @@
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
     },
+    "standard-engine": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-12.0.0.tgz",
+      "integrity": "sha512-gJIIRb0LpL7AHyGbN9+hJ4UJns37lxmNTnMGRLC8CFrzQ+oB/K60IQjKNgPBCB2VP60Ypm6f8DFXvhVWdBOO+g==",
+      "dev": true,
+      "requires": {
+        "deglob": "^4.0.0",
+        "get-stdin": "^7.0.0",
+        "minimist": "^1.1.0",
+        "pkg-conf": "^3.1.0"
+      }
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -13118,6 +13499,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "mocha": "^6.2.0",
     "mochawesome": "^4.1.0",
     "mock-fs": "^4.10.1",
+    "nock": "^11.3.1",
     "nyc": "^14.1.1",
     "semistandard": "^14.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "mochawesome": "^4.1.0",
     "mock-fs": "^4.10.1",
     "nyc": "^14.1.1",
-    "semistandard": "^14.0.1"
+    "semistandard": "^14.1.0"
   },
   "engines": {
     "node": ">=10.16.0"

--- a/src/server/Manifest.js
+++ b/src/server/Manifest.js
@@ -5,6 +5,16 @@ const https = require('https');
  */
 class Manifest extends Map {
   /**
+   * Lazy getter for a cached instance with prefetched versions from default URL
+   * @return {Promise}
+   */
+  static get default () {
+    delete Manifest.default;
+    Manifest.default = (new Manifest()).fetch();
+    return Manifest.default;
+  }
+
+  /**
    * @param  {URL} url
    */
   set url (url) {

--- a/src/server/Manifest.js
+++ b/src/server/Manifest.js
@@ -1,3 +1,4 @@
+const https = require('https');
 /**
  * Map, that can fetch, parse, download and update Minecraft Server versions
  * @extends Map
@@ -16,8 +17,32 @@ class Manifest extends Map {
   get url () {
     return this.customUrl || Manifest.url;
   }
+
+  /**
+   * Fetches the Minecraft version manifest from "this.url" and parses it
+   * @return {Promise} Resolves to 'this' or rejects with an Error object
+   */
+  fetch () {
+    return new Promise((resolve, reject) => {
+      https.get(this.url, (response) => {
+        let data = '';
+        response.on('data', chunk => { data += chunk; });
+        response.on('end', () => {
+          JSON.parse(data).versions.forEach(({ id, type, url, releaseTime }) => {
+            if (Manifest.types.has(type)) {
+              this.set(id, { type, url, age: Date.parse(releaseTime) });
+            }
+          });
+          resolve(this);
+        });
+      }).on('error', reject);
+    });
+  }
 }
 // Default manifest URL string, so as not to store copies in every instance
 Manifest.url = new URL('https://launchermeta.mojang.com/mc/game/version_manifest.json');
+// The default Set of version type strings to include when parsing the manifest
+// NOTE: Should be per instance customizable, but not sure how to implement that
+Manifest.types = new Set(['release', 'snapshot']);
 
 module.exports = Manifest;

--- a/src/server/Manifest.js
+++ b/src/server/Manifest.js
@@ -1,0 +1,23 @@
+/**
+ * Map, that can fetch, parse, download and update Minecraft Server versions
+ * @extends Map
+ */
+class Manifest extends Map {
+  /**
+   * @param  {URL} url
+   */
+  set url (url) {
+    this.customUrl = url.href === Manifest.url.href ? undefined : url;
+  }
+
+  /**
+   * @return {URL}
+   */
+  get url () {
+    return this.customUrl || Manifest.url;
+  }
+}
+// Default manifest URL string, so as not to store copies in every instance
+Manifest.url = new URL('https://launchermeta.mojang.com/mc/game/version_manifest.json');
+
+module.exports = Manifest;

--- a/src/server/Manifest.js
+++ b/src/server/Manifest.js
@@ -29,6 +29,17 @@ class Manifest extends Map {
   }
 
   /**
+   * @param  {String} type Type of id which to search for
+   * @return {String} Latest version id found of given type or overall
+   */
+  latest (type) {
+    // We assume that versions are in chronological order with latest first
+    return type && Manifest.types.has(type)
+      ? [...this.keys()].find(id => this.get(id).type === type)
+      : this.keys().next().value;
+  }
+
+  /**
    * Fetches the Minecraft version manifest from "this.url" and parses it
    * @return {Promise} Resolves to 'this' or rejects with an Error object
    */

--- a/src/server/Manifest.js
+++ b/src/server/Manifest.js
@@ -40,6 +40,16 @@ class Manifest extends Map {
   }
 
   /**
+   * See "downlod()" for version syntax
+   * @param  {String} version Version which to update
+   * @return {Promise} Resolves to latest version id of given / evaluated type
+   */
+  update (version) {
+    const [id, type] = version.split('@');
+    return this.latest(type || (this.get(id) || { type: false }).type);
+  }
+
+  /**
    * Fetches the Minecraft version manifest from "this.url" and parses it
    * @return {Promise} Resolves to 'this' or rejects with an Error object
    */

--- a/src/server/MinecraftServer.js
+++ b/src/server/MinecraftServer.js
@@ -123,8 +123,6 @@ class MinecraftServer {
     const minecraftDirectory = properties.settings.minecraftDirectory;
     let minecraftWasRunning = false;
     const backupDir = path.resolve(properties.settings.backups.path);
-    let archive;
-    let output;
 
     worldName = worldName || 'world';
     if (properties.started) {
@@ -133,8 +131,8 @@ class MinecraftServer {
     }
 
     await fs.ensureDir(backupDir, { recursive: true });
-    output = await fs.createWriteStream(path.join(backupDir, `${worldName}_${Util.getDateTime()}.zip`));
-    archive = archiver('zip', {
+    const output = await fs.createWriteStream(path.join(backupDir, `${worldName}_${Util.getDateTime()}.zip`));
+    const archive = archiver('zip', {
       zlib: { level: 9 }
     });
     archive.pipe(output);
@@ -315,9 +313,9 @@ class MinecraftServer {
       if (release.full !== detectedVersion.full) {
         if (release.major > detectedVersion.major) {
           this.properties.updateAvailable = true;
-        } else if (release.major == detectedVersion.major && release.minor > detectedVersion.minor) {
+        } else if (release.major === detectedVersion.major && release.minor > detectedVersion.minor) {
           this.properties.updateAvailable = true;
-        } else if (release.major == detectedVersion.major && release.minor == detectedVersion.minor && release.release > detectedVersion.release) {
+        } else if (release.major === detectedVersion.major && release.minor === detectedVersion.minor && release.release > detectedVersion.release) {
           this.properties.updateAvailable = true;
         }
         await this.log(`Minecraft version ${release.full} available.`);
@@ -1387,7 +1385,7 @@ class MinecraftServer {
     await this.log('Waiting on Minecraft buffer...');
     await Util.wait(time);
     if (properties.serverOutputCaptured) {
-      if (serverOutput.length && serverOutput.length != length) {
+      if (serverOutput.length && serverOutput.length !== length) {
         await this.log(`Minecraft buffer appers to be full with ${serverOutput.length} entries.`);
       } else {
         if (time < max) {

--- a/test/server/manifest.js
+++ b/test/server/manifest.js
@@ -46,4 +46,30 @@ describe('Manifest', function () {
       });
     });
   });
+  describe('instance', function () {
+    before(async function () {
+      this.manifest = await Manifest.default;
+    });
+    it('should extend Map', function () {
+      assert.ok(this.manifest instanceof Map);
+    });
+    it('should hold hold type, url and age of version', async function () {
+      this.manifest.forEach(({ type, url, age }, id) => {
+        assert.ok(Manifest.types.has(type));
+        assert.equal(new URL(url).href, url);
+        assert.ok(Number.isSafeInteger(age));
+      });
+    });
+    describe('url', function () {
+      it('should store a custom URL', function () {
+        const url = new URL('https://not.quite.mojang/mc/game/manifest.json');
+        this.manifest.url = url;
+        assert.equal(this.manifest.url, url);
+      });
+      it('should not store the default URL', function () {
+        this.manifest.url = Manifest.url;
+        assert.equal(this.manifest.url, Manifest.url);
+      });
+    });
+  });
 });

--- a/test/server/manifest.js
+++ b/test/server/manifest.js
@@ -71,5 +71,12 @@ describe('Manifest', function () {
         assert.equal(this.manifest.url, Manifest.url);
       });
     });
+    describe('fetch()', function () {
+      it('should return own instance', async function () {
+        nock(Manifest.url.origin).get(Manifest.url.pathname).reply(200, this.mcm);
+        // Kind of tests that returned data is still sane
+        assert.deepEqual(this.manifest, await this.manifest.fetch());
+      });
+    });
   });
 });

--- a/test/server/manifest.js
+++ b/test/server/manifest.js
@@ -71,6 +71,19 @@ describe('Manifest', function () {
         assert.equal(this.manifest.url, Manifest.url);
       });
     });
+    describe('latest()', function () {
+      it('should return latest id overall when invalid type', async function () {
+        const reducer = (latest, id) => this.manifest.get(id).age > this.manifest.get(latest).age ? id : latest;
+        assert.equal(this.manifest.latest(), [...this.manifest.keys()].reduce(reducer));
+      });
+      it('should return latest ids for all "Manifest.types"', async function () {
+        const reducer = (latest, id) => this.manifest.get(id).age > this.manifest.get(latest).age ? id : latest;
+        Manifest.types.forEach(type => {
+          const filtered = [...this.manifest.keys()].filter(id => this.manifest.get(id).type === type);
+          assert.equal(this.manifest.latest(type), filtered.reduce(reducer));
+        });
+      });
+    });
     describe('fetch()', function () {
       it('should return own instance', async function () {
         nock(Manifest.url.origin).get(Manifest.url.pathname).reply(200, this.mcm);

--- a/test/server/manifest.js
+++ b/test/server/manifest.js
@@ -1,0 +1,49 @@
+const { describe, it, before, after } = require('mocha');
+const assert = require('assert').strict;
+const mock = require('mock-fs');
+const https = require('https');
+const nock = require('nock');
+const path = require('path');
+
+const Manifest = require(path.resolve('src', 'server', 'Manifest.js'));
+
+describe('Manifest', function () {
+  before(async function () {
+    // NOTE: This is a bit reundant
+    nock.restore();
+    // The official Minecraft version manifest
+    this.mcm = await new Promise((resolve, reject) => {
+      https.get(Manifest.url, (response) => {
+        let data = '';
+        response.on('data', chunk => { data += chunk; });
+        response.on('end', () => { resolve(JSON.parse(data)); });
+      }).on('error', reject);
+    });
+    nock.disableNetConnect();
+    nock.activate();
+  });
+  describe('static', function () {
+    describe('url', function () {
+      it('should be an instance of URL', function () {
+        assert.ok(Manifest.url instanceof URL);
+      });
+    });
+    describe('types', function () {
+      it('should be an instance of Set', function () {
+        assert.ok(Manifest.types instanceof Set);
+      });
+    });
+    describe('default', function () {
+      it('should resolve to an instance of Manifest', async function () {
+        nock(Manifest.url.origin).get(Manifest.url.pathname).reply(200, this.mcm);
+        const instance = Manifest.default;
+        assert.ok(instance instanceof Promise);
+        assert.ok(await instance instanceof Manifest);
+      });
+      it('should be cached after first look up', async function () {
+        assert.ok(!Object.getOwnPropertyDescriptor(Manifest, 'default').get);
+        assert.ok(await Manifest.default instanceof Manifest);
+      });
+    });
+  });
+});

--- a/test/server/manifest.js
+++ b/test/server/manifest.js
@@ -48,6 +48,7 @@ describe('Manifest', function () {
   });
   describe('instance', function () {
     before(async function () {
+      this.id = '1.9-pre4';
       this.manifest = await Manifest.default;
     });
     it('should extend Map', function () {
@@ -82,6 +83,17 @@ describe('Manifest', function () {
           const filtered = [...this.manifest.keys()].filter(id => this.manifest.get(id).type === type);
           assert.equal(this.manifest.latest(type), filtered.reduce(reducer));
         });
+      });
+    });
+    describe('update()', function () {
+      it('should return latest snapshot when given a snapshot id', function () {
+        assert.equal(this.manifest.update(this.id), this.manifest.latest('snapshot'));
+      });
+      it('should return latest release when given a release type', function () {
+        assert.equal(this.manifest.update(`${this.id}@release`), this.manifest.latest('release'));
+      });
+      it('should return latest version when given an invalid id', function () {
+        assert.equal(this.manifest.update('latest'), this.manifest.latest());
       });
     });
     describe('fetch()', function () {


### PR DESCRIPTION
See commit messages for some details.
Also adds hash checking of downloaded file

This is what I meant by removing console spam in #45. `console.log()` messages could be added when these operations start and end in the functions that call them, rather than in the functions themselves